### PR TITLE
Make POSIX shell script work in POSIX shell

### DIFF
--- a/swaylock-corrupter
+++ b/swaylock-corrupter
@@ -3,7 +3,7 @@
 if [ "$1" = "--help" ]  ||  [ "$1" = "-h" ]; then
 	swaylock --help 2>&1| sed -r 's/swaylock/swaylock-corrupter/g' | sed '/--image/d'
 else
-	DISPLAYS=`swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}'`
+	DISPLAYS=$(swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}')
 	BASE_FILE="/tmp/ss"
  
 	args=""

--- a/swaylock-corrupter
+++ b/swaylock-corrupter
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$1" = "--help" ]  ||  [ "$1" = "-h" ]; then
-	swaylock --help 2>&1| sed -Ee 's/swaylock/swaylock-corrupter/g' -e '/--image/d' 1>&2
+	swaylock --help 2>&1| sed -e 's/swaylock/swaylock-corrupter/g' -e '/--image/d' 1>&2
 else
 	DISPLAYS="$(swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}')"
 	BASE_FILE="${TMPDIR:-/tmp/ss}"

--- a/swaylock-corrupter
+++ b/swaylock-corrupter
@@ -6,7 +6,7 @@ else
 	DISPLAYS="$(swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}')"
 	BASE_FILE="${TMPDIR:-/tmp/ss}"
  
-	for display in "$DISPLAYS"; do
+	for display in $DISPLAYS; do
 		FILE="${BASE_FILE}${display}.png"
 		grim -o "$display" "$FILE"
 		corrupter "$FILE" "$FILE"

--- a/swaylock-corrupter
+++ b/swaylock-corrupter
@@ -3,17 +3,17 @@
 if [ "$1" = "--help" ]  ||  [ "$1" = "-h" ]; then
 	swaylock --help 2>&1| sed -r 's/swaylock/swaylock-corrupter/g' | sed '/--image/d'
 else
-	DISPLAYS=$(swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}')
+	DISPLAYS="$(swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}')"
 	BASE_FILE="/tmp/ss"
  
-	for display in $DISPLAYS; do
-		FILE=${BASE_FILE}${display}.png
-		grim -o $display $FILE
-		corrupter $FILE $FILE
+	for display in "$DISPLAYS"; do
+		FILE="${BASE_FILE}${display}.png"
+		grim -o "$display" "$FILE"
+		corrupter "$FILE" "$FILE"
 		args="$args -i ${display}:${FILE}"
 	done
  
-	swaylock $args $@
+	swaylock $args "$@"
 	# double monitor fix by /u/queyenth
 fi
 

--- a/swaylock-corrupter
+++ b/swaylock-corrupter
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$1" = "--help" ]  ||  [ "$1" = "-h" ]; then
-	swaylock --help 2>&1| sed -Ee 's/swaylock/swaylock-corrupter/g' -e '/--image/d'
+	swaylock --help 2>&1| sed -Ee 's/swaylock/swaylock-corrupter/g' -e '/--image/d' 1>&2
 else
 	DISPLAYS="$(swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}')"
 	BASE_FILE="/tmp/ss"

--- a/swaylock-corrupter
+++ b/swaylock-corrupter
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [[ $# -gt 0 ]] &&  [[ $1 == "--help" ]]  ||  [[ $1 == "-h" ]]; then
-	swaylock --help |& sed -r 's/swaylock/swaylock-corrupter/g' | sed '/--image/d'
+if [ "$1" = "--help" ]  ||  [ "$1" = "-h" ]; then
+	swaylock --help 2>&1| sed -r 's/swaylock/swaylock-corrupter/g' | sed '/--image/d'
 else
 	DISPLAYS=`swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}'`
 	BASE_FILE="/tmp/ss"

--- a/swaylock-corrupter
+++ b/swaylock-corrupter
@@ -4,7 +4,7 @@ if [ "$1" = "--help" ]  ||  [ "$1" = "-h" ]; then
 	swaylock --help 2>&1| sed -Ee 's/swaylock/swaylock-corrupter/g' -e '/--image/d' 1>&2
 else
 	DISPLAYS="$(swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}')"
-	BASE_FILE="/tmp/ss"
+	BASE_FILE="${TMPDIR:-/tmp/ss}"
  
 	for display in "$DISPLAYS"; do
 		FILE="${BASE_FILE}${display}.png"

--- a/swaylock-corrupter
+++ b/swaylock-corrupter
@@ -7,10 +7,10 @@ else
 	BASE_FILE="/tmp/ss"
  
 	for display in $DISPLAYS; do
-	FILE=${BASE_FILE}${display}.png
-	grim -o $display $FILE
-	corrupter $FILE $FILE
-	args="$args -i ${display}:${FILE}"
+		FILE=${BASE_FILE}${display}.png
+		grim -o $display $FILE
+		corrupter $FILE $FILE
+		args="$args -i ${display}:${FILE}"
 	done
  
 	swaylock $args $@

--- a/swaylock-corrupter
+++ b/swaylock-corrupter
@@ -6,8 +6,6 @@ else
 	DISPLAYS=$(swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}')
 	BASE_FILE="/tmp/ss"
  
-	args=""
- 
 	for display in $DISPLAYS; do
 	FILE=${BASE_FILE}${display}.png
 	grim -o $display $FILE

--- a/swaylock-corrupter
+++ b/swaylock-corrupter
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$1" = "--help" ]  ||  [ "$1" = "-h" ]; then
-	swaylock --help 2>&1| sed -r 's/swaylock/swaylock-corrupter/g' | sed '/--image/d'
+	swaylock --help 2>&1| sed -Ee 's/swaylock/swaylock-corrupter/g' -e '/--image/d'
 else
 	DISPLAYS="$(swaymsg -t get_outputs -p | grep "Output" | awk '{print $2}')"
 	BASE_FILE="/tmp/ss"


### PR DESCRIPTION
Fixed the shell script to remove any secret dependencies on `/bin/sh` actually being a Bash symlink. Also fixed a bunch of shell quoting issues, fixed temp file creation, and cleaned up a few random things.

For the future, it's worth checking for these kinds of problems with [ShellCheck](https://www.shellcheck.net/).